### PR TITLE
doc: remove default preset-create-react-app addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Once installed, add this preset to the appropriate file:
     addons: ["storybook-preset-craco"],
   };
   ```
+  
+  **Note**: Don't forget to comment or remove the `@storybook/preset-create-react-app` from `addons`.
 
 ### Usage with Docs
 


### PR DESCRIPTION
Add note for comment/removing default `@storybook/preset-create-react-app` from `addons`.

I've added to make it clear for newbies to prevent them from confusing and struggling with the problem.